### PR TITLE
[FEAT] 프로그래머스 웹사이트 크롤링 작업 1차

### DIFF
--- a/py/crawling.py
+++ b/py/crawling.py
@@ -1,0 +1,63 @@
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.options import Options
+from bs4 import BeautifulSoup
+import sys
+import time
+
+# Python 출력 인코딩 UTF-8로 설정
+sys.stdout.reconfigure(encoding='utf-8')
+
+# ChromeDriver 경로 설정 및 옵션
+options = Options()
+options.add_argument("--lang=ko")  # 브라우저 언어를 한국어로 설정
+options.add_argument("--headless")  # 브라우저 창을 표시하지 않음
+options.add_argument("--disable-gpu")  # GPU 사용 안 함
+options.add_argument("--no-sandbox")  # 샌드박스 모드 비활성화
+
+service = Service(r"C:\Program Files\chromedriver\chromedriver.exe")  # Chromedriver 경로
+driver = webdriver.Chrome(service=service, options=options)
+
+# 기본 URL 설정
+base_url = "https://school.programmers.co.kr/learn/challenges?order=acceptance_desc&levels=1%2C2&languages=java&page="
+
+# 페이지 탐색
+page = 1
+while True:
+    url = f"{base_url}{page}"
+    driver.get(url)
+    time.sleep(2)  # 페이지 로딩 대기
+
+    # 페이지 소스 가져오기
+    html = driver.page_source
+    soup = BeautifulSoup(html, "html.parser")
+
+    # 'bookmark' div에서 <a> 태그 추출
+    bookmarks = soup.select("div.bookmark a")
+
+    # 'td.level' 내 'span' 태그에서 클래스 이름 추출
+    levels = soup.select("td.level span")
+
+    # 'td.acceptance-rate'에서 숫자 추출
+    acceptance_rates = soup.select("td.acceptance-rate")
+
+    # 데이터가 없으면 루프 종료
+    if not bookmarks:
+        print("No more data found. Ending scraping.")
+        break
+
+    # 추출한 데이터 출력
+    for i, bookmark in enumerate(bookmarks):
+        href = bookmark.get("href")
+        text = bookmark.text.strip()
+        level = levels[i].get("class")[0] if i < len(levels) else "N/A"
+        rate = acceptance_rates[i].text.strip() if i < len(acceptance_rates) else "N/A"
+        if href:
+            lesson_id = href.split("/")[-1]
+            print(f"ID: {lesson_id}, 제목: {text}, Level: {level}, Rate: {rate}")
+
+    # 다음 페이지로 이동
+    page += 1
+
+# WebDriver 종료
+driver.quit()


### PR DESCRIPTION
문제번호, 문제이름 , 레벨, 정답률 순으로 가지고 올 수 있으며
다음 작업으로 문제 안에 있는 문제와 정답을 가져와야 합니다. 
만약 사용해보고 싶으시다면,

1. 파이썬 설치
2. Chrome Driver 설치 하신 후에 service 경로를 잡아주셔야합니다.

크롤링 정도의 기능은 여기서 구현하고, 정답을 도출하고 학습 또는 주석에 대한 이야기는 추후에 나누면 좋을거 같습니다. 

![image](https://github.com/user-attachments/assets/ed8bb4d6-02c1-43a0-985f-3c3353dc7e96)
