### PR TITLE
test 프로필 추가

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    url: "${TEST_DB_URL}"
+    username: "${TEST_DB_USERNAME}"
+    password: "${TEST_DB_PASSWORD}"
+
+server:
+  port: 8008

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,3 @@ spring:
 
 logging.level:
   org.hibernate.SQL: debug
-
-server:
-  port: 8008


### PR DESCRIPTION
## 변경사항
### 1. test 프로필 추가
- 테스트 서버에서 사용할 수 있는 `application-test.yml`을 추가했습니다.
- 해당 설정 파일에는 테스트 전용 DB의 정보가 들어있습니다.

### 2. 테스트 서버 배포가 용이하도록 쉘 스크립트 작성
- EC2 인스턴스에 다음과 같은 쉘 스크립트를 추가했습니다.
![image](https://github.com/user-attachments/assets/012317a9-5a86-4a27-b848-5dcaf049c58d)
- 명령어 `./deploy_test.sh`를 입력하면, 
  - test_dev 디렉토리로 이동. main 브랜치 기준으로 pull
  - 기존에 8008에서 실행 중인 애플리케이션 종료
  - 새로운 애플리케이션 빌드해서 실행하도록 구성했습니다.
- 우선은 빠르게 적용할 수 있도록 이렇게 쉘 스크립트를 만든 것이고, 추후 이 부분을 CI/CD 파이프라인을 구축하는 방식으로 변경하면 좋을 것 같습니다.