### PR TITLE
[FEAT] 이미지 테이블 컬럼 추가 멤버 정보 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
     //Spring Data Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/mildo/dev/api/code/repository/CodeRepository.java
+++ b/src/main/java/com/mildo/dev/api/code/repository/CodeRepository.java
@@ -21,5 +21,8 @@ public interface CodeRepository extends JpaRepository<CodeEntity, Long> {
             "FROM CodeEntity c JOIN c.problemEntity p WHERE c.memberEntity.memberId = :memberId ORDER BY c.codeSolvedDate DESC")
     List<CodeSolvedListDTO> findSolvedProblemListByMemberId(@Param("memberId") String memberId, Pageable pageable);
 
+    @Query("SELECT new com.mildo.dev.api.code.domain.dto.CodeSolvedListDTO(c.codeNo, c.problemEntity.problemTitle, c.problemEntity.problemLevel, c.problemEntity.problemType, c.codeSolvedDate, c.codeTime)" +
+            "FROM CodeEntity c JOIN c.problemEntity p WHERE c.memberEntity.memberId = :memberId AND (:title IS NULL OR c.problemEntity.problemTitle LIKE %:title%) ORDER BY c.codeSolvedDate DESC")
+    List<CodeSolvedListDTO> findSolvedProblemListTitleByMemberId(@Param("memberId") String memberId, @Param("title") String title, Pageable pageable);
 
 }

--- a/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
+++ b/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
@@ -76,10 +76,11 @@ public class MemberController {
     @GetMapping(value="/{memberId}/solved/problem", produces="application/json; charset=UTF-8")
     public ResponseEntity<?> solvedProblem(@PathVariable String memberId,
                                            @RequestParam(defaultValue = "0") int page,
-                                           @RequestParam(defaultValue = "10") int size)
+                                           @RequestParam(defaultValue = "10") int size,
+                                           @RequestParam(required = false) String title)
     {
         try{
-            SolvedListResponse solvedProblemList = userService.solvedProblemList(memberId, page, size);
+            SolvedListResponse solvedProblemList = userService.solvedProblemList(memberId, page, size, title);
             return ResponseEntity.status(HttpStatus.OK).body(solvedProblemList);
         } catch (IllegalArgumentException e){
             throw  new RuntimeException(e.getMessage());

--- a/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
+++ b/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
@@ -21,7 +21,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -96,9 +98,27 @@ public class MemberController {
 
     @ResponseBody
     @GetMapping(value = "/member/info", produces="application/json; charset=UTF-8")
-    public ResponseEntity<?> updateUser(@RequestBody TokenRedis vo) {
+    public ResponseEntity<?> memberInfo(@RequestBody TokenRedis vo) {
         MemberInfoDTO memberInfo = userService.memberInfo(vo.getMemberId());
         return ResponseEntity.status(HttpStatus.OK).body(memberInfo);
+    }
+
+    @ResponseBody
+    @PatchMapping(value = "/member/info", produces="application/json; charset=UTF-8")
+    public ResponseEntity<?> updateUser(@RequestBody MemberInfoDTO vo) {
+        MemberInfoDTO res = userService.updateUser(vo);
+        return ResponseEntity.status(HttpStatus.OK).body(res);
+    }
+
+    @ResponseBody
+    @PutMapping(value="/{memberId}/upload", produces="application/json; charset=UTF-8")
+    public ResponseEntity<?> uploadFile(@RequestParam("file") MultipartFile file, @PathVariable String memberId) {
+        try {
+            MemberInfoDTO dto = userService.uploadImg(file, memberId);
+            return ResponseEntity.ok(dto);
+        } catch (IOException e) {
+            throw  new RuntimeException("File not found");
+        }
     }
 
     @GetMapping("/test")

--- a/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
+++ b/src/main/java/com/mildo/dev/api/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.mildo.dev.api.code.domain.dto.CodeLevelDTO;
 import com.mildo.dev.api.code.domain.dto.CodeSolvedListDTO;
 import com.mildo.dev.api.code.domain.dto.SolvedListResponse;
 import com.mildo.dev.api.code.domain.dto.SolvedProblemResponse;
+import com.mildo.dev.api.member.domain.dto.MemberInfoDTO;
 import com.mildo.dev.api.member.domain.dto.TokenDto;
 import com.mildo.dev.api.member.domain.dto.TokenRedis;
 import com.mildo.dev.api.member.service.MemberService;
@@ -91,6 +92,13 @@ public class MemberController {
         userService.tokenDelete(memberId.getMemberId());
         CookieUtil.deleteRefreshTokenCookie(response);
         return ResponseEntity.status(HttpStatus.OK).body("로그아웃 성공");
+    }
+
+    @ResponseBody
+    @GetMapping(value = "/member/info", produces="application/json; charset=UTF-8")
+    public ResponseEntity<?> updateUser(@RequestBody TokenRedis vo) {
+        MemberInfoDTO memberInfo = userService.memberInfo(vo.getMemberId());
+        return ResponseEntity.status(HttpStatus.OK).body(memberInfo);
     }
 
     @GetMapping("/test")

--- a/src/main/java/com/mildo/dev/api/member/customoauth/handler/CustomOAuthUserService.java
+++ b/src/main/java/com/mildo/dev/api/member/customoauth/handler/CustomOAuthUserService.java
@@ -7,6 +7,7 @@ import com.mildo.dev.api.member.repository.MemberRepository;
 import com.mildo.dev.api.utils.random.CodeGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -20,6 +21,9 @@ public class CustomOAuthUserService extends DefaultOAuth2UserService {
     public CustomOAuthUserService(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }
+
+    @Value("${BASIC_URL}")
+    private String basic;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) {
@@ -44,6 +48,7 @@ public class CustomOAuthUserService extends DefaultOAuth2UserService {
                     .googleId(googleId)
                     .email(email)
                     .leader("N")
+                    .imgUrl(basic)
                     .build();
             memberRepository.save(member);
 

--- a/src/main/java/com/mildo/dev/api/member/domain/dto/MemberInfoDTO.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/dto/MemberInfoDTO.java
@@ -1,18 +1,17 @@
 package com.mildo.dev.api.member.domain.dto;
 
-import com.mildo.dev.api.member.domain.entity.MemberImgEntity;
 import lombok.*;
 
-
+@ToString
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class MemberInfoDTO {
 
     private String memberId;
-    private String studyId;
     private String name;
     private String email;
-    private MemberImgEntity memberImgEntity;
+    private String studyId;
+    private String imgUrl;
 
 }

--- a/src/main/java/com/mildo/dev/api/member/domain/dto/MemberInfoDTO.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/dto/MemberInfoDTO.java
@@ -1,0 +1,18 @@
+package com.mildo.dev.api.member.domain.dto;
+
+import com.mildo.dev.api.member.domain.entity.MemberImgEntity;
+import lombok.*;
+
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberInfoDTO {
+
+    private String memberId;
+    private String studyId;
+    private String name;
+    private String email;
+    private MemberImgEntity memberImgEntity;
+
+}

--- a/src/main/java/com/mildo/dev/api/member/domain/dto/TokenDto.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/dto/TokenDto.java
@@ -3,7 +3,6 @@ package com.mildo.dev.api.member.domain.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/com/mildo/dev/api/member/domain/entity/MemberEntity.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/entity/MemberEntity.java
@@ -58,6 +58,9 @@ public class MemberEntity {
     @CreationTimestamp
     private Timestamp createDate; // 유저 생성일
 
+    @Column(name = "member_img_url")
+    private String imgUrl;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id")
     private StudyEntity studyEntity;
@@ -71,8 +74,8 @@ public class MemberEntity {
     @OneToOne(mappedBy = "memberEntity")
     private TokenEntity tokenEntity;
 
-    @OneToOne(mappedBy = "memberEntity")
-    @JsonManagedReference
-    private MemberImgEntity memberImgEntity;
+//    @OneToOne(mappedBy = "memberEntity")
+//    @JsonManagedReference
+//    private MemberImgEntity memberImgEntity;
 
 }

--- a/src/main/java/com/mildo/dev/api/member/domain/entity/MemberEntity.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/entity/MemberEntity.java
@@ -1,5 +1,6 @@
 package com.mildo.dev.api.member.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.mildo.dev.api.code.domain.entity.CodeEntity;
 import com.mildo.dev.api.code.domain.entity.CommentEntity;
 import com.mildo.dev.api.study.domain.entity.StudyEntity;
@@ -12,11 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.sql.Date;
@@ -24,6 +21,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -72,5 +70,9 @@ public class MemberEntity {
 
     @OneToOne(mappedBy = "memberEntity")
     private TokenEntity tokenEntity;
+
+    @OneToOne(mappedBy = "memberEntity")
+    @JsonManagedReference
+    private MemberImgEntity memberImgEntity;
 
 }

--- a/src/main/java/com/mildo/dev/api/member/domain/entity/MemberImgEntity.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/entity/MemberImgEntity.java
@@ -1,6 +1,7 @@
 package com.mildo.dev.api.member.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.mildo.dev.api.member.domain.dto.MemberInfoDTO;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -27,9 +28,9 @@ public class MemberImgEntity {
     @Column(name = "img_change_name")
     private String imgChangeName;
 
-    @OneToOne
-    @JoinColumn(name = "member_id")
-    @JsonBackReference
-    private MemberEntity memberEntity;
+//    @OneToOne
+//    @JoinColumn(name = "member_id")
+//    @JsonBackReference
+//    private MemberEntity memberEntity;
 
 }

--- a/src/main/java/com/mildo/dev/api/member/domain/entity/MemberImgEntity.java
+++ b/src/main/java/com/mildo/dev/api/member/domain/entity/MemberImgEntity.java
@@ -1,0 +1,35 @@
+package com.mildo.dev.api.member.domain.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@Entity
+@Table(name = "member_img")
+public class MemberImgEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "img_no")
+    private String imgNo;
+
+    @Column(name = "img_url")
+    private String imgUrl;
+
+    @Column(name = "img_origin_name")
+    private String imgOriginName;
+
+    @Column(name = "img_change_name")
+    private String imgChangeName;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    @JsonBackReference
+    private MemberEntity memberEntity;
+
+}

--- a/src/main/java/com/mildo/dev/api/member/service/MemberService.java
+++ b/src/main/java/com/mildo/dev/api/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.mildo.dev.api.code.domain.dto.CodeSolvedListDTO;
 import com.mildo.dev.api.code.domain.dto.SolvedListResponse;
 import com.mildo.dev.api.code.domain.dto.SolvedProblemResponse;
 import com.mildo.dev.api.code.repository.CodeRepository;
+import com.mildo.dev.api.member.domain.dto.MemberInfoDTO;
 import com.mildo.dev.api.member.domain.dto.TokenDto;
 import com.mildo.dev.api.member.domain.dto.TokenRedis;
 import com.mildo.dev.api.member.domain.entity.MemberEntity;
@@ -124,6 +125,16 @@ public class MemberService {
             token.setRefreshExpirationTime(null);
             tokenRepository.save(token);
         }
+    }
+
+    public MemberInfoDTO memberInfo(String memberId){
+        return memberRepository.findByMemberId(memberId).map(member -> new MemberInfoDTO(
+                member.getMemberId(),
+                member.getName(),
+                member.getEmail(),
+                member.getStudyEntity().getStudyId(),
+                member.getMemberImgEntity()
+        )).orElseThrow(() -> new RuntimeException("Member not found"));
     }
 
 }

--- a/src/main/java/com/mildo/dev/api/member/service/MemberService.java
+++ b/src/main/java/com/mildo/dev/api/member/service/MemberService.java
@@ -115,10 +115,18 @@ public class MemberService {
         return new SolvedProblemResponse(CodeLeverCount);
     }
 
-    public SolvedListResponse solvedProblemList(String memberId, int page, int size){
+    public SolvedListResponse solvedProblemList(String memberId, int page, int size, String title){
         vaildMemberId(memberId);
         Pageable pageable = PageRequest.of(page, size);
-        List<CodeSolvedListDTO> results = codeRepository.findSolvedProblemListByMemberId(memberId, pageable);
+
+        List<CodeSolvedListDTO> results;
+        if (title != null && !title.isEmpty()) {
+            results = codeRepository.findSolvedProblemListTitleByMemberId(memberId, title, pageable);
+        } else {
+            results = codeRepository.findSolvedProblemListByMemberId(memberId, pageable);
+        }
+
+
         return new SolvedListResponse(results);
     }
 

--- a/src/main/java/com/mildo/dev/api/utils/cookie/CookieUtil.java
+++ b/src/main/java/com/mildo/dev/api/utils/cookie/CookieUtil.java
@@ -11,7 +11,7 @@ public class CookieUtil {
         cookie.setSecure(true); // HTTPS에서만 전송
         cookie.setPath("/"); // 애플리케이션 전체에서 접근 가능
         cookie.setMaxAge(maxAge); // 쿠키 만료 시간
-        cookie.setDomain("dev.mildo.xyz"); // 도메인 설정
+        cookie.setDomain("test.mildo.xyz"); // 도메인 설정
         cookie.setAttribute("SameSite", "None"); // SameSite 설정
         return cookie;
     }
@@ -22,10 +22,10 @@ public class CookieUtil {
         myCookie.setPath("/");
         myCookie.setHttpOnly(true);
         myCookie.setSecure(true);
-        myCookie.setDomain("dev.mildo.xyz");
+        myCookie.setDomain("test.mildo.xyz");
         myCookie.setAttribute("SameSite", "None");
         response.addCookie(myCookie);
-        response.setHeader("Set-Cookie", "RefreshToken=; Path=/; Domain=dev.mildo.xyz; Max-Age=0; Secure; HttpOnly; SameSite=None");
+        response.setHeader("Set-Cookie", "RefreshToken=; Path=/; Domain=test.mildo.xyz; Max-Age=0; Secure; HttpOnly; SameSite=None");
     }
 
 }

--- a/src/main/java/com/mildo/dev/global/config/s3/S3Config.java
+++ b/src/main/java/com/mildo/dev/global/config/s3/S3Config.java
@@ -1,0 +1,29 @@
+package com.mildo.dev.global.config.s3;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secretkey}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,15 @@
+cloud:
+  aws:
+    credentials:
+      access-key: "${S3_ACCESS_KEY}"
+      secret-key: "${S3_SECRET_KEY}"
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: "${bucket}"
+    stack:
+      auto: false
+
 spring:
   datasource:
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
1. ERD에 프로필 이미지 테이블 생성 및 엔티티 컬럼 추가 했습니다.
2. MemberEntity 클래스 MemberImgEntity 클래스에  OneToOne 으로 되있어 조회하고 DTO에 적용하면 무한 재귀 호출 발생하여 부모 클래스에는 @JsonManagedReference 설정 자식 클래스에는 @JsonBackReference 어노테이션 붙혔습니다. JSON 직렬화 시 @JsonBackReference가 걸려 있는 필드는 제외해서 무한 재귀 호출을 방지하였습니다. 다른 좋은 방법있으면 피드백 부탁드리겠습니다.